### PR TITLE
Add config bootstrap modes

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -26,13 +26,14 @@ If neither is set, sloppy-joe runs with default settings (no canonical rules, no
 
 ## Config Format
 
-JSON file with eight top-level keys. All are optional.
+JSON file with optional top-level keys. The most common policy keys are:
 
 ```json
 {
   "canonical": { ... },
   "internal": { ... },
   "allowed": { ... },
+  "bootstrap_review": { ... },
   "similarity_exceptions": { ... },
   "metadata_exceptions": { ... },
   "min_version_age_hours": 72,
@@ -107,6 +108,29 @@ Lists vetted external packages that should skip existence and similarity checks 
 - Metadata signals (install scripts + other risk factors, dependency explosion, maintainer changes)
 
 **When to use:** For legitimate external packages that trigger false positives on similarity checks (e.g., a package with a name close to a popular one that you've manually verified).
+
+### `bootstrap_review`
+
+Carries review-only bootstrap suggestions produced by `sloppy-joe init --from-current`.
+
+```json
+{
+  "bootstrap_review": {
+    "candidate_canonical_groups": {
+      "npm": [
+        {
+          "packages": ["dayjs", "moment"],
+          "reason": "Multiple packages from the same solution family are already in use."
+        }
+      ]
+    }
+  }
+}
+```
+
+**What it does:** Nothing at scan time. This section is informational only.
+
+**When to use:** Keep it while reviewing bootstrap output from `--from-current`. Move reviewed decisions into `canonical` when you are ready to enforce them.
 
 **Difference from internal:** Internal packages skip everything. Allowed packages skip only existence and similarity.
 
@@ -219,13 +243,42 @@ Valid values:
 
 Legacy Python support still fails closed on unsafe forms. For example, direct URLs, editable requirements, local paths, VCS sources, and unsupported dynamic dependency declarations are rejected rather than silently skipped.
 
-## Generating a Template
+## Bootstrap Modes
 
 ```bash
-sloppy-joe init > config.json
+sloppy-joe init --register
 ```
 
-This outputs a starter config with example values for all ecosystems.
+This creates a neutral starter config outside the repo and registers it for the current git root.
+
+For new projects, use an ecosystem-specific greenfield starter:
+
+```bash
+sloppy-joe init --greenfield --ecosystem npm
+sloppy-joe init --greenfield --ecosystem cargo --register
+```
+
+For existing repos, seed config from the current codebase:
+
+```bash
+sloppy-joe init --from-current
+```
+
+`--from-current` writes the config outside the repo, registers it automatically, and populates:
+
+- likely `internal` package patterns for local/workspace packages
+- trusted local Cargo paths discovered from the current repo
+- `bootstrap_review.candidate_canonical_groups` suggestions for families that need human review before becoming enforced canonicals
+
+Those `bootstrap_review` suggestions are informational. They do not change enforcement until you move them into `canonical`.
+
+If you need to manage the file yourself, write it to a secure location outside the project directory:
+
+```bash
+sloppy-joe init > /secure/location/sloppy-joe.json
+```
+
+Do not write the config into the repo itself. sloppy-joe intentionally refuses in-repo config files.
 
 ## CI Integration
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -116,6 +116,12 @@ Carries review-only bootstrap suggestions produced by `sloppy-joe init --from-cu
 ```json
 {
   "bootstrap_review": {
+    "suggested_internal": {
+      "npm": ["@acme/web", "@acme/ui"]
+    },
+    "suggested_trusted_local_paths": {
+      "cargo": ["/opt/company/shared-crate"]
+    },
     "candidate_canonical_groups": {
       "npm": [
         {
@@ -258,16 +264,23 @@ sloppy-joe init --greenfield --ecosystem npm
 sloppy-joe init --greenfield --ecosystem cargo --register
 ```
 
+Greenfield presets are currently implemented for `npm`, `pypi`, and `cargo`. Other ecosystems fail with a clear “not supported yet” error instead of emitting an empty starter.
+
 For existing repos, seed config from the current codebase:
 
 ```bash
 sloppy-joe init --from-current
+sloppy-joe init --from-current --register
 ```
 
-`--from-current` writes the config outside the repo, registers it automatically, and populates:
+`--from-current` currently supports only repos whose first-party code is `npm` and/or `cargo`. Other ecosystems fail with a clear “not implemented yet” error.
 
-- likely `internal` package patterns for local/workspace packages
-- trusted local Cargo paths discovered from the current repo
+By default, `--from-current` prints review-only bootstrap output. Add `--register` to write the generated config outside the repo and register it for the current git root.
+
+It populates:
+
+- `bootstrap_review.suggested_internal` for discovered first-party local packages
+- `bootstrap_review.suggested_trusted_local_paths` for discovered out-of-repo Cargo path dependencies
 - `bootstrap_review.candidate_canonical_groups` suggestions for families that need human review before becoming enforced canonicals
 
 Those `bootstrap_review` suggestions are informational. They do not change enforcement until you move them into `canonical`.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ sloppy-joe init --register
 # Create an ecosystem-specific greenfield starter policy
 sloppy-joe init --greenfield --ecosystem npm
 
-# Seed config from the current repo and register it automatically
+# Print review-only bootstrap suggestions for an npm or Cargo repo
 sloppy-joe init --from-current
+
+# Or write/register those suggestions safely outside the repo
+sloppy-joe init --from-current --register
 
 # Or write a config manually to a secure path outside the repo
 sloppy-joe init > /secure/location/sloppy-joe.json
@@ -97,8 +100,8 @@ nix profile install github:brennhill/sloppy-joe
 **Config sources:** local file path, HTTPS URL, or `SLOPPY_JOE_CONFIG` env var. Config is never read from the project directory (see [CONFIG.md](CONFIG.md) for why).
 
 **Onboarding:** use the bootstrap mode that matches the repo:
-- `sloppy-joe init --greenfield --ecosystem <eco>` prints an ecosystem-specific starter policy for new projects. Add `--register` to write it outside the repo and register it safely.
-- `sloppy-joe init --from-current` inspects the current repo, writes a config outside the repo, and registers it automatically for the current git root.
+- `sloppy-joe init --greenfield --ecosystem <eco>` prints an ecosystem-specific starter policy for new projects. Today, greenfield presets are implemented for `npm`, `pypi`, and `cargo`; other ecosystems fail with a “not supported yet” error. Add `--register` to write it outside the repo and register it safely.
+- `sloppy-joe init --from-current` inspects the current repo and prints review-only bootstrap suggestions. Today, `--from-current` is implemented only for repos whose first-party code is `npm` and/or `cargo`; other ecosystems fail closed with a “not implemented yet” error. Add `--register` to write and register the generated config.
 - `sloppy-joe init` with no mode prints a neutral manual template.
 
 **Release automation:** pushing a tag like `v0.8.0` triggers a GitHub Releases build for `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `aarch64-apple-darwin`, and `x86_64-pc-windows-msvc`. Release binaries are built with `cargo auditable` metadata embedded and gated by `cargo audit bin` before publication.
@@ -484,6 +487,7 @@ Bootstrap config:
 ```bash
 sloppy-joe init --greenfield --ecosystem npm
 sloppy-joe init --from-current
+sloppy-joe init --from-current --register
 sloppy-joe init > /secure/location/config.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,17 @@ sloppy-joe check --json
 # Review exact maintainer-change exceptions with evidence
 sloppy-joe check --review-exceptions
 
-# Generate a starter config
-sloppy-joe init > config.json
+# Create and register a safe per-repo config outside the repo
+sloppy-joe init --register
+
+# Create an ecosystem-specific greenfield starter policy
+sloppy-joe init --greenfield --ecosystem npm
+
+# Seed config from the current repo and register it automatically
+sloppy-joe init --from-current
+
+# Or write a config manually to a secure path outside the repo
+sloppy-joe init > /secure/location/sloppy-joe.json
 ```
 
 ### Nix
@@ -86,6 +95,11 @@ nix profile install github:brennhill/sloppy-joe
 | .NET / NuGet | `.csproj` | strict: `packages.lock.json` |
 
 **Config sources:** local file path, HTTPS URL, or `SLOPPY_JOE_CONFIG` env var. Config is never read from the project directory (see [CONFIG.md](CONFIG.md) for why).
+
+**Onboarding:** use the bootstrap mode that matches the repo:
+- `sloppy-joe init --greenfield --ecosystem <eco>` prints an ecosystem-specific starter policy for new projects. Add `--register` to write it outside the repo and register it safely.
+- `sloppy-joe init --from-current` inspects the current repo, writes a config outside the repo, and registers it automatically for the current git root.
+- `sloppy-joe init` with no mode prints a neutral manual template.
 
 **Release automation:** pushing a tag like `v0.8.0` triggers a GitHub Releases build for `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `aarch64-apple-darwin`, and `x86_64-pc-windows-msvc`. Release binaries are built with `cargo auditable` metadata embedded and gated by `cargo audit bin` before publication.
 
@@ -466,8 +480,10 @@ Malformed configs **fail hard** with actionable error messages — a broken conf
 
 See [CONFIG.md](CONFIG.md) for full format reference, CI integration patterns, and examples.
 
-Generate a template:
+Bootstrap config:
 ```bash
+sloppy-joe init --greenfield --ecosystem npm
+sloppy-joe init --from-current
 sloppy-joe init > /secure/location/config.json
 ```
 

--- a/docs/specs/config-bootstrap.md
+++ b/docs/specs/config-bootstrap.md
@@ -44,10 +44,14 @@ Purpose:
 - seed config from what the repo already uses
 - shorten adoption time for real projects
 
+Current implementation boundary:
+- supports only repos whose first-party code is `npm` and/or `cargo`
+- other ecosystems must fail closed with a clear “not implemented yet” error
+- plain `--from-current` prints review-only output; add `--register` to write/register it
+
 Should discover:
-- likely `internal` patterns
-- trusted scopes and package roots
-- workspace/local-package provenance
+- review-only `suggested_internal` entries for first-party local packages
+- review-only `suggested_trusted_local_paths` for external Cargo path deps
 - reviewable candidate canonical groups
 
 Should not do silently:
@@ -56,8 +60,8 @@ Should not do silently:
 - weaken security controls to “make it pass”
 
 Output model:
-- write config outside the repo
-- register it automatically for the current git root
+- print review-only config by default
+- optionally write config outside the repo and register it when `--register` is used
 - surface discoveries as either:
   - accepted config entries
   - or review-required suggestions when confidence is lower
@@ -74,6 +78,7 @@ The supported safe paths are:
 sloppy-joe init --register
 sloppy-joe init --greenfield --ecosystem npm
 sloppy-joe init --from-current
+sloppy-joe init --from-current --register
 ```
 
 or, for manual placement:

--- a/docs/specs/config-bootstrap.md
+++ b/docs/specs/config-bootstrap.md
@@ -1,0 +1,85 @@
+# Config Bootstrap Direction
+
+**Status:** Implemented  
+**Date:** 2026-04-03
+
+## Problem
+
+`sloppy-joe` is strict about config placement for good reasons: the active policy file must live outside the repo. That security choice is correct, but the onboarding UX is still too manual:
+
+- a generic template is not the same thing as a usable policy
+- the starter config mixes example data with real security controls
+- existing repos have no discovery-assisted path for seeding `internal`, trusted scopes, package roots, or candidate canonicals
+
+The product needs a first-use flow that is both safe and fast.
+
+## Direction
+
+Bootstrap should become explicit instead of one generic `init` blob.
+
+### 1. Greenfield mode
+
+```bash
+sloppy-joe init --greenfield --ecosystem <eco>
+```
+
+Purpose:
+- create an opinionated starter policy for a new project
+- keep defaults ecosystem-specific instead of shipping one mixed template
+- avoid fake org-specific data like `@yourorg/*` unless the user explicitly supplies it
+
+Rules:
+- write outside the repo or combine with `--register`
+- emit only policy that is defensible as a default for that ecosystem
+- prefer warnings or reviewable suggestions over aggressive canonicals when there is no repo context
+
+### 2. Existing repo discovery mode
+
+```bash
+sloppy-joe init --from-current
+```
+
+Purpose:
+- inspect the current codebase
+- seed config from what the repo already uses
+- shorten adoption time for real projects
+
+Should discover:
+- likely `internal` patterns
+- trusted scopes and package roots
+- workspace/local-package provenance
+- reviewable candidate canonical groups
+
+Should not do silently:
+- invent hard canonical policy and enforce it as fact
+- mark third-party packages as `allowed` without review
+- weaken security controls to “make it pass”
+
+Output model:
+- write config outside the repo
+- register it automatically for the current git root
+- surface discoveries as either:
+  - accepted config entries
+  - or review-required suggestions when confidence is lower
+
+### 3. Neutral default template
+
+If `init` is used without mode flags, the output should be a neutral manual template, not a disguised policy bundle with example canonicals and fake org data.
+
+## Current recommendation
+
+The supported safe paths are:
+
+```bash
+sloppy-joe init --register
+sloppy-joe init --greenfield --ecosystem npm
+sloppy-joe init --from-current
+```
+
+or, for manual placement:
+
+```bash
+sloppy-joe init > /secure/location/sloppy-joe.json
+```
+
+Never write the active config into the repo itself.

--- a/docs/superpowers/plans/2026-04-03-config-bootstrap.md
+++ b/docs/superpowers/plans/2026-04-03-config-bootstrap.md
@@ -1,0 +1,192 @@
+# Config Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add explicit config bootstrap modes so greenfield repos get ecosystem-specific starter policies, existing repos can seed config from current code, and the default template becomes neutral instead of shipping fake org/example policy.
+
+**Architecture:** Extend `init` with two new modes: `--greenfield --ecosystem <eco>` and `--from-current`. Keep config files outside the repo, reuse existing registry/config-home flows for safe placement, and add a discovery layer that inspects the current repo for internals, trusted scopes/package roots, and candidate canonicals while preserving human review for low-confidence policy.
+
+**Tech Stack:** Rust, Clap CLI parsing, existing config/template/registry modules, serde JSON serialization, cargo test/clippy/fmt.
+
+---
+
+## Files In Scope
+
+- [ ] Modify [src/main.rs](/Users/brenn/dev/sloppy-joe/src/main.rs) for new `init` mode flags, validation, and safe bootstrap UX.
+- [ ] Modify [src/config/mod.rs](/Users/brenn/dev/sloppy-joe/src/config/mod.rs) for neutral template generation, ecosystem-specific greenfield presets, and discovery helpers.
+- [ ] Add or extend tests in [src/main.rs](/Users/brenn/dev/sloppy-joe/src/main.rs) and [src/config/mod.rs](/Users/brenn/dev/sloppy-joe/src/config/mod.rs).
+- [ ] Update [README.md](/Users/brenn/dev/sloppy-joe/README.md) and [CONFIG.md](/Users/brenn/dev/sloppy-joe/CONFIG.md) to document the new bootstrap modes.
+
+## Task 1: Add failing CLI tests for bootstrap modes
+
+**Files:**
+- Modify: [src/main.rs](/Users/brenn/dev/sloppy-joe/src/main.rs)
+
+- [ ] **Step 1: Write failing CLI tests**
+  Add tests for:
+  - `init --greenfield --ecosystem npm`
+  - `init --from-current`
+  - missing `--ecosystem` with `--greenfield` is rejected
+  - `--greenfield` conflicts with `--from-current`
+  - `--greenfield`/`--from-current` conflict with `--global`
+
+- [ ] **Step 2: Run targeted tests to verify they fail**
+
+  Run:
+  ```bash
+  cargo test --quiet --bin sloppy-joe init_
+  ```
+
+- [ ] **Step 3: Add minimal CLI parsing support**
+  Add the new flags and conflict rules to `Commands::Init`.
+
+- [ ] **Step 4: Re-run targeted tests**
+
+  Run:
+  ```bash
+  cargo test --quiet --bin sloppy-joe init_
+  ```
+
+## Task 2: Replace the generic example template with a neutral baseline
+
+**Files:**
+- Modify: [src/config/mod.rs](/Users/brenn/dev/sloppy-joe/src/config/mod.rs)
+
+- [ ] **Step 1: Write failing template tests**
+  Add tests proving the default template:
+  - does not contain fake org data like `@yourorg/*`
+  - does not contain sample allowlisted packages
+  - does not contain opinionated npm/Python canonicals by default
+
+- [ ] **Step 2: Run targeted tests to verify they fail**
+
+  Run:
+  ```bash
+  cargo test --quiet template_
+  ```
+
+- [ ] **Step 3: Implement the neutral baseline template**
+  Make plain `init` a manual starter, not a disguised policy pack.
+
+- [ ] **Step 4: Re-run targeted tests**
+
+  Run:
+  ```bash
+  cargo test --quiet template_
+  ```
+
+## Task 3: Add ecosystem-specific greenfield presets
+
+**Files:**
+- Modify: [src/config/mod.rs](/Users/brenn/dev/sloppy-joe/src/config/mod.rs)
+- Modify: [src/main.rs](/Users/brenn/dev/sloppy-joe/src/main.rs)
+
+- [ ] **Step 1: Write failing preset tests**
+  Add tests for:
+  - `greenfield_config("npm")` emits npm-focused starter policy only
+  - `greenfield_config("cargo")` emits Cargo-focused starter policy only
+  - unsupported ecosystems are rejected with a clear error
+
+- [ ] **Step 2: Run targeted tests to verify they fail**
+
+  Run:
+  ```bash
+  cargo test --quiet greenfield_
+  ```
+
+- [ ] **Step 3: Implement `greenfield_config` and wire it into `init --greenfield`**
+  Keep config placement safe by reusing the current out-of-repo write path.
+
+- [ ] **Step 4: Re-run targeted tests**
+
+  Run:
+  ```bash
+  cargo test --quiet greenfield_
+  ```
+
+## Task 4: Add `--from-current` repo discovery
+
+**Files:**
+- Modify: [src/config/mod.rs](/Users/brenn/dev/sloppy-joe/src/config/mod.rs)
+- Modify: [src/main.rs](/Users/brenn/dev/sloppy-joe/src/main.rs)
+
+- [ ] **Step 1: Write failing discovery tests**
+  Add tests for discovery helpers that:
+  - infer likely npm internal scopes from local/workspace packages
+  - infer Cargo internal/local provenance from workspace/path crates
+  - derive trusted similarity roots/scopes from current package usage
+  - produce reviewable candidate canonical groups instead of hard-enforcing them
+
+- [ ] **Step 2: Run targeted tests to verify they fail**
+
+  Run:
+  ```bash
+  cargo test --quiet from_current_
+  ```
+
+- [ ] **Step 3: Implement minimal discovery helpers**
+  Scope the first pass to data already available from repo manifests and bindings. Do not fetch online metadata.
+
+- [ ] **Step 4: Wire discovery into `init --from-current`**
+  Output a safe external config and register it automatically for the current git root.
+
+- [ ] **Step 5: Re-run targeted tests**
+
+  Run:
+  ```bash
+  cargo test --quiet from_current_
+  ```
+
+## Task 5: Update messaging and docs
+
+**Files:**
+- Modify: [src/main.rs](/Users/brenn/dev/sloppy-joe/src/main.rs)
+- Modify: [README.md](/Users/brenn/dev/sloppy-joe/README.md)
+- Modify: [CONFIG.md](/Users/brenn/dev/sloppy-joe/CONFIG.md)
+
+- [ ] **Step 1: Update `sloppy-joe init --help` text**
+  Document:
+  - neutral default template
+  - `--greenfield --ecosystem <eco>`
+  - `--from-current`
+  - safe config placement outside the repo
+
+- [ ] **Step 2: Update README quickstart**
+  Make the safe onboarding path obvious and short.
+
+- [ ] **Step 3: Update CONFIG docs**
+  Document what each bootstrap mode does, and what `--from-current` intentionally does not auto-enforce.
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Run targeted binary tests**
+
+  Run:
+  ```bash
+  cargo test --quiet --bin sloppy-joe
+  ```
+
+- [ ] **Step 2: Run focused library tests**
+
+  Run:
+  ```bash
+  cargo test --quiet template_
+  cargo test --quiet greenfield_
+  cargo test --quiet from_current_
+  ```
+
+- [ ] **Step 3: Run full verification**
+
+  Run:
+  ```bash
+  cargo test --quiet
+  cargo clippy --all-targets --all-features -- -D warnings
+  cargo fmt --check
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add src/main.rs src/config/mod.rs README.md CONFIG.md
+  git commit -m "Add config bootstrap modes"
+  ```

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -190,12 +190,18 @@ pub struct CanonicalGroupSuggestion {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BootstrapReview {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub suggested_internal: HashMap<String, Vec<String>>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub suggested_trusted_local_paths: HashMap<String, Vec<String>>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub candidate_canonical_groups: HashMap<String, Vec<CanonicalGroupSuggestion>>,
 }
 
 impl BootstrapReview {
     fn is_empty(&self) -> bool {
-        self.candidate_canonical_groups.is_empty()
+        self.suggested_internal.is_empty()
+            && self.suggested_trusted_local_paths.is_empty()
+            && self.candidate_canonical_groups.is_empty()
     }
 }
 
@@ -1035,9 +1041,10 @@ pub fn greenfield_config(ecosystem: &str) -> Result<SloppyJoeConfig, String> {
             );
         }
         "go" | "ruby" | "php" | "jvm" | "dotnet" => {
-            config
-                .canonical
-                .insert(ecosystem.to_string(), HashMap::new());
+            return Err(format!(
+                "Greenfield bootstrap for '{}' is not supported yet. Current greenfield presets exist for: npm, pypi, cargo.",
+                ecosystem
+            ));
         }
         other => {
             return Err(format!(
@@ -1058,48 +1065,40 @@ pub fn greenfield_json(ecosystem: &str) -> Result<String, String> {
 #[derive(Default)]
 struct DiscoveryState {
     npm_local_packages: BTreeSet<String>,
-    npm_scope_counts: HashMap<String, usize>,
     npm_dependency_usage: BTreeSet<String>,
     cargo_local_packages: BTreeSet<String>,
     cargo_external_paths: BTreeSet<String>,
+    unsupported_ecosystems: BTreeSet<String>,
+    saw_supported_ecosystem: bool,
 }
 
 impl DiscoveryState {
     fn into_config(self) -> SloppyJoeConfig {
         let mut config = template_config();
 
-        let mut npm_internal = Vec::new();
-        let mut scope_globs = BTreeSet::new();
-        for (scope, count) in &self.npm_scope_counts {
-            if *count > 1 {
-                scope_globs.insert(scope.clone());
-                npm_internal.push(format!("{scope}/*"));
-            }
-        }
-        for package in self.npm_local_packages {
-            if let Some(scope) = extract_npm_scope(&package)
-                && scope_globs.contains(scope)
-            {
-                continue;
-            }
-            npm_internal.push(package);
-        }
+        let npm_internal: Vec<String> = self.npm_local_packages.into_iter().collect();
         if !npm_internal.is_empty() {
-            config.internal.insert("npm".to_string(), npm_internal);
+            config
+                .bootstrap_review
+                .suggested_internal
+                .insert("npm".to_string(), npm_internal);
         }
 
         if !self.cargo_local_packages.is_empty() {
-            config.internal.insert(
+            config.bootstrap_review.suggested_internal.insert(
                 "cargo".to_string(),
                 self.cargo_local_packages.into_iter().collect(),
             );
         }
 
         if !self.cargo_external_paths.is_empty() {
-            config.trusted_local_paths.insert(
-                "cargo".to_string(),
-                self.cargo_external_paths.into_iter().collect(),
-            );
+            config
+                .bootstrap_review
+                .suggested_trusted_local_paths
+                .insert(
+                    "cargo".to_string(),
+                    self.cargo_external_paths.into_iter().collect(),
+                );
         }
 
         let npm_groups = candidate_canonical_groups(
@@ -1202,7 +1201,18 @@ fn discover_repo_state(
             let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
                 continue;
             };
-            if matches!(name, ".git" | "node_modules" | "target") {
+            if matches!(
+                name,
+                ".git"
+                    | "node_modules"
+                    | "target"
+                    | "vendor"
+                    | "dist"
+                    | "build"
+                    | "third_party"
+                    | "fixtures"
+                    | "testdata"
+            ) {
                 continue;
             }
             discover_repo_state(&path, root, visited, state)?;
@@ -1210,8 +1220,39 @@ fn discover_repo_state(
         }
 
         match path.file_name().and_then(|name| name.to_str()) {
-            Some("package.json") => inspect_package_json(&path, state)?,
-            Some("Cargo.toml") => inspect_cargo_manifest(&path, root, state)?,
+            Some("package.json") => {
+                state.saw_supported_ecosystem = true;
+                inspect_package_json(&path, state)?;
+            }
+            Some("Cargo.toml") => {
+                state.saw_supported_ecosystem = true;
+                inspect_cargo_manifest(&path, root, state)?;
+            }
+            Some("pyproject.toml")
+            | Some("Pipfile")
+            | Some("setup.py")
+            | Some("setup.cfg")
+            | Some("requirements.txt") => {
+                state.unsupported_ecosystems.insert("pypi".to_string());
+            }
+            Some(name) if name.starts_with("requirements") && name.ends_with(".txt") => {
+                state.unsupported_ecosystems.insert("pypi".to_string());
+            }
+            Some("go.mod") => {
+                state.unsupported_ecosystems.insert("go".to_string());
+            }
+            Some("Gemfile") => {
+                state.unsupported_ecosystems.insert("ruby".to_string());
+            }
+            Some("composer.json") => {
+                state.unsupported_ecosystems.insert("php".to_string());
+            }
+            Some("build.gradle") | Some("build.gradle.kts") | Some("pom.xml") => {
+                state.unsupported_ecosystems.insert("jvm".to_string());
+            }
+            _ if path.extension().is_some_and(|ext| ext == "csproj") => {
+                state.unsupported_ecosystems.insert("dotnet".to_string());
+            }
             _ => {}
         }
     }
@@ -1240,9 +1281,6 @@ fn inspect_package_json(path: &Path, state: &mut DiscoveryState) -> Result<(), S
         let name = name.trim();
         if !name.is_empty() {
             state.npm_local_packages.insert(name.to_string());
-            if let Some(scope) = extract_npm_scope(name) {
-                *state.npm_scope_counts.entry(scope.to_string()).or_insert(0) += 1;
-            }
         }
     }
 
@@ -1345,6 +1383,22 @@ pub fn discover_current_config(project_dir: &Path) -> Result<SloppyJoeConfig, St
     let mut visited = BTreeSet::new();
     let mut state = DiscoveryState::default();
     discover_repo_state(project_dir, &root, &mut visited, &mut state)?;
+    if !state.unsupported_ecosystems.is_empty() {
+        return Err(format!(
+            "`sloppy-joe init --from-current` currently supports only npm and cargo repos. Detected unsupported ecosystems: {}. Support for those ecosystems is not implemented yet.",
+            state
+                .unsupported_ecosystems
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if !state.saw_supported_ecosystem {
+        return Err(
+            "`sloppy-joe init --from-current` currently supports only npm and cargo repos. No supported manifests were detected.".to_string(),
+        );
+    }
     Ok(state.into_config())
 }
 
@@ -1593,6 +1647,14 @@ mod tests {
     }
 
     #[test]
+    fn greenfield_config_rejects_not_yet_supported_ecosystem() {
+        let err = greenfield_config("go").expect_err("unsupported greenfield ecosystems must fail");
+        assert!(err.contains("not supported yet"));
+        assert!(err.contains("npm"));
+        assert!(err.contains("cargo"));
+    }
+
+    #[test]
     fn greenfield_config_rejects_unknown_ecosystem() {
         let err = greenfield_config("elixir").expect_err("unsupported ecosystems must fail");
         assert!(err.contains("Unsupported ecosystem"));
@@ -1627,8 +1689,12 @@ mod tests {
         let config =
             discover_current_config(&dir).expect("discovery should inspect npm workspaces");
         assert_eq!(
-            config.internal.get("npm"),
-            Some(&vec!["@acme/*".to_string()])
+            config.bootstrap_review.suggested_internal.get("npm"),
+            Some(&vec!["@acme/ui".to_string(), "@acme/web".to_string()])
+        );
+        assert!(
+            config.internal.is_empty(),
+            "from-current should not silently trust discovered packages"
         );
         assert!(
             !config.canonical.contains_key("npm"),
@@ -1691,15 +1757,71 @@ version = "0.1.0"
             discover_current_config(&repo).expect("discovery should inspect cargo manifests");
         let canonical_external = std::fs::canonicalize(&external).unwrap();
         assert_eq!(
-            config.internal.get("cargo"),
+            config.bootstrap_review.suggested_internal.get("cargo"),
             Some(&vec!["app".to_string(), "lib".to_string()])
         );
         assert_eq!(
-            config.trusted_local_paths.get("cargo"),
+            config
+                .bootstrap_review
+                .suggested_trusted_local_paths
+                .get("cargo"),
             Some(&vec![canonical_external.to_string_lossy().to_string()])
+        );
+        assert!(
+            config.trusted_local_paths.is_empty(),
+            "from-current should not silently trust local cargo paths"
         );
 
         std::fs::remove_dir_all(&sandbox).unwrap();
+    }
+
+    #[test]
+    fn discover_current_config_rejects_unsupported_ecosystems() {
+        let dir = unique_temp_dir("from-current-unsupported");
+        write_file(&dir.join("requirements.txt"), "requests==2.32.3\n");
+
+        let err = discover_current_config(&dir)
+            .expect_err("unsupported ecosystems should fail until implemented");
+        assert!(err.contains("supports only npm and cargo"));
+        assert!(err.contains("pypi"));
+        assert!(err.contains("not implemented yet"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn discover_current_config_skips_vendor_and_fixture_trees() {
+        let dir = unique_temp_dir("from-current-skips");
+        write_file(
+            &dir.join("app/package.json"),
+            r#"{"name":"@acme/app","dependencies":{"dayjs":"1.11.13"}}"#,
+        );
+        write_file(
+            &dir.join("vendor/third-party/package.json"),
+            r#"{"name":"left-pad","dependencies":{"moment":"2.30.1"}}"#,
+        );
+        write_file(
+            &dir.join("fixtures/sample/package.json"),
+            r#"{"name":"@fixture/sample","dependencies":{"got":"14.4.8"}}"#,
+        );
+
+        let config = discover_current_config(&dir).expect("discovery should ignore vendored trees");
+        assert_eq!(
+            config.bootstrap_review.suggested_internal.get("npm"),
+            Some(&vec!["@acme/app".to_string()])
+        );
+        let groups = config
+            .bootstrap_review
+            .candidate_canonical_groups
+            .get("npm")
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            groups.is_empty(),
+            "vendored fixtures must not leak into review suggestions"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,7 +1,7 @@
 pub mod registry;
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 
 /// Config format:
@@ -180,6 +180,25 @@ impl MetadataException {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CanonicalGroupSuggestion {
+    pub packages: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapReview {
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub candidate_canonical_groups: HashMap<String, Vec<CanonicalGroupSuggestion>>,
+}
+
+impl BootstrapReview {
+    fn is_empty(&self) -> bool {
+        self.candidate_canonical_groups.is_empty()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SloppyJoeConfig {
     #[serde(default)]
@@ -208,6 +227,8 @@ pub struct SloppyJoeConfig {
     pub cargo_git_policy: CargoGitPolicy,
     #[serde(default = "default_python_enforcement")]
     pub python_enforcement: PythonEnforcement,
+    #[serde(default, skip_serializing_if = "BootstrapReview::is_empty")]
+    pub bootstrap_review: BootstrapReview,
     #[serde(skip)]
     pub allow_host_local_cargo_config: bool,
     #[serde(skip)]
@@ -247,6 +268,7 @@ impl Default for SloppyJoeConfig {
             trusted_git_sources: HashMap::new(),
             cargo_git_policy: default_cargo_git_policy(),
             python_enforcement: default_python_enforcement(),
+            bootstrap_review: BootstrapReview::default(),
             allow_host_local_cargo_config: false,
             active_local_overlay_relaxations: Vec::new(),
         }
@@ -678,7 +700,7 @@ pub fn load_config_with_project(
 
         let content = std::fs::read_to_string(path).map_err(|e| {
             format!(
-                "Could not read config file: {}\n  Path: {}\n  Fix: Check that the file exists and is readable.\n       Use 'sloppy-joe init > config.json' to generate a template.",
+                "Could not read config file: {}\n  Path: {}\n  Fix: Check that the file exists and is readable.\n       Use 'sloppy-joe init --register' or write a template to a safe external path with 'sloppy-joe init > /secure/sloppy-joe.json'.",
                 e, path.display()
             )
         })?;
@@ -792,7 +814,7 @@ fn redact_url_for_display(url: &str) -> String {
 fn parse_config_content(content: &str, source: &str) -> Result<SloppyJoeConfig, String> {
     if content.trim().is_empty() {
         return Err(format!(
-            "Config is empty.\n  Source: {}\n  Fix: Use 'sloppy-joe init > config.json' to generate a template.",
+            "Config is empty.\n  Source: {}\n  Fix: Use 'sloppy-joe init > /secure/location/sloppy-joe.json' to generate a template outside the repo.",
             source
         ));
     }
@@ -959,79 +981,380 @@ fn ensure_config_outside_project(path: &Path, project_dir: Option<&Path>) -> Res
 }
 
 /// Build the template config used by init.
+///
+/// This is a manual starting point, not a finished policy for an existing repo.
+/// Future onboarding should prefer explicit greenfield presets or a
+/// `--from-current` discovery flow over one generic example blob.
 fn template_config() -> SloppyJoeConfig {
-    SloppyJoeConfig {
-        canonical: {
-            let mut m = HashMap::new();
-            m.insert(
+    SloppyJoeConfig::default()
+}
+
+fn render_config_json(config: &SloppyJoeConfig) -> String {
+    serde_json::to_string_pretty(config).expect("SloppyJoeConfig should always serialize")
+}
+
+fn supported_bootstrap_ecosystems() -> &'static [&'static str] {
+    &["npm", "pypi", "cargo", "go", "ruby", "php", "jvm", "dotnet"]
+}
+
+pub fn greenfield_config(ecosystem: &str) -> Result<SloppyJoeConfig, String> {
+    let mut config = template_config();
+    match ecosystem {
+        "npm" => {
+            config.canonical.insert(
                 "npm".to_string(),
                 HashMap::from([
-                    (
-                        "lodash".to_string(),
-                        vec!["underscore".to_string(), "ramda".to_string()],
-                    ),
-                    (
-                        "dayjs".to_string(),
-                        vec!["moment".to_string(), "luxon".to_string()],
-                    ),
-                    (
-                        "axios".to_string(),
-                        vec![
-                            "request".to_string(),
-                            "got".to_string(),
-                            "node-fetch".to_string(),
-                            "superagent".to_string(),
-                        ],
-                    ),
+                    ("eslint".to_string(), vec!["tslint".to_string()]),
+                    ("dayjs".to_string(), vec!["moment".to_string()]),
                 ]),
             );
-            m.insert(
+        }
+        "pypi" => {
+            config.canonical.insert(
                 "pypi".to_string(),
+                HashMap::from([(
+                    "ruff".to_string(),
+                    vec![
+                        "flake8".to_string(),
+                        "pylint".to_string(),
+                        "pyflakes".to_string(),
+                    ],
+                )]),
+            );
+        }
+        "cargo" => {
+            config.canonical.insert(
+                "cargo".to_string(),
                 HashMap::from([
                     (
-                        "httpx".to_string(),
-                        vec!["urllib3".to_string(), "requests".to_string()],
+                        "thiserror".to_string(),
+                        vec!["failure".to_string(), "error-chain".to_string()],
                     ),
-                    (
-                        "ruff".to_string(),
-                        vec!["flake8".to_string(), "pylint".to_string()],
-                    ),
+                    ("clap".to_string(), vec!["structopt".to_string()]),
                 ]),
             );
-            m.insert("cargo".to_string(), HashMap::new());
-            m.insert("go".to_string(), HashMap::new());
-            m.insert("ruby".to_string(), HashMap::new());
-            m.insert("php".to_string(), HashMap::new());
-            m.insert("jvm".to_string(), HashMap::new());
-            m.insert("dotnet".to_string(), HashMap::new());
-            m
-        },
-        internal: HashMap::from([
-            ("go".to_string(), vec!["github.com/yourorg/*".to_string()]),
-            ("npm".to_string(), vec!["@yourorg/*".to_string()]),
-        ]),
-        allowed: HashMap::from([(
-            "npm".to_string(),
-            vec!["some-vetted-external-pkg".to_string()],
-        )]),
-        similarity_exceptions: HashMap::new(),
-        metadata_exceptions: HashMap::new(),
-        min_version_age_hours: 72,
-        allow_unresolved_versions: false,
-        allow_legacy_npm_v1_lockfile: false,
-        trusted_local_paths: HashMap::new(),
-        trusted_registries: HashMap::new(),
-        trusted_git_sources: HashMap::new(),
-        cargo_git_policy: default_cargo_git_policy(),
-        python_enforcement: default_python_enforcement(),
-        allow_host_local_cargo_config: false,
-        active_local_overlay_relaxations: Vec::new(),
+        }
+        "go" | "ruby" | "php" | "jvm" | "dotnet" => {
+            config
+                .canonical
+                .insert(ecosystem.to_string(), HashMap::new());
+        }
+        other => {
+            return Err(format!(
+                "Unsupported ecosystem '{}'. Expected one of: {}.",
+                other,
+                supported_bootstrap_ecosystems().join(", ")
+            ));
+        }
     }
+
+    Ok(config)
+}
+
+pub fn greenfield_json(ecosystem: &str) -> Result<String, String> {
+    greenfield_config(ecosystem).map(|config| render_config_json(&config))
+}
+
+#[derive(Default)]
+struct DiscoveryState {
+    npm_local_packages: BTreeSet<String>,
+    npm_scope_counts: HashMap<String, usize>,
+    npm_dependency_usage: BTreeSet<String>,
+    cargo_local_packages: BTreeSet<String>,
+    cargo_external_paths: BTreeSet<String>,
+}
+
+impl DiscoveryState {
+    fn into_config(self) -> SloppyJoeConfig {
+        let mut config = template_config();
+
+        let mut npm_internal = Vec::new();
+        let mut scope_globs = BTreeSet::new();
+        for (scope, count) in &self.npm_scope_counts {
+            if *count > 1 {
+                scope_globs.insert(scope.clone());
+                npm_internal.push(format!("{scope}/*"));
+            }
+        }
+        for package in self.npm_local_packages {
+            if let Some(scope) = extract_npm_scope(&package)
+                && scope_globs.contains(scope)
+            {
+                continue;
+            }
+            npm_internal.push(package);
+        }
+        if !npm_internal.is_empty() {
+            config.internal.insert("npm".to_string(), npm_internal);
+        }
+
+        if !self.cargo_local_packages.is_empty() {
+            config.internal.insert(
+                "cargo".to_string(),
+                self.cargo_local_packages.into_iter().collect(),
+            );
+        }
+
+        if !self.cargo_external_paths.is_empty() {
+            config.trusted_local_paths.insert(
+                "cargo".to_string(),
+                self.cargo_external_paths.into_iter().collect(),
+            );
+        }
+
+        let npm_groups = candidate_canonical_groups(
+            &self.npm_dependency_usage,
+            &[
+                &["dayjs", "moment", "luxon"],
+                &["axios", "got", "node-fetch", "superagent"],
+                &["eslint", "tslint"],
+                &["jest", "vitest", "mocha", "ava"],
+            ],
+            "Multiple packages from the same solution family are already in use. Review whether one should become canonical.",
+        );
+        if !npm_groups.is_empty() {
+            config
+                .bootstrap_review
+                .candidate_canonical_groups
+                .insert("npm".to_string(), npm_groups);
+        }
+
+        config
+    }
+}
+
+fn candidate_canonical_groups(
+    used_packages: &BTreeSet<String>,
+    families: &[&[&str]],
+    reason: &str,
+) -> Vec<CanonicalGroupSuggestion> {
+    let mut groups = Vec::new();
+    for family in families {
+        let packages: Vec<String> = family
+            .iter()
+            .filter(|package| used_packages.contains(**package))
+            .map(|package| (*package).to_string())
+            .collect();
+        if packages.len() >= 2 {
+            groups.push(CanonicalGroupSuggestion {
+                packages,
+                reason: Some(reason.to_string()),
+            });
+        }
+    }
+    groups
+}
+
+fn discover_repo_state(
+    current_dir: &Path,
+    root: &Path,
+    visited: &mut BTreeSet<PathBuf>,
+    state: &mut DiscoveryState,
+) -> Result<(), String> {
+    let canonical_current = std::fs::canonicalize(current_dir).map_err(|err| {
+        format!(
+            "Failed to inspect {} while seeding config from the current repo: {}",
+            current_dir.display(),
+            err
+        )
+    })?;
+
+    if !canonical_current.starts_with(root) {
+        return Err(format!(
+            "Refusing to follow directory '{}' outside the current repo root.",
+            current_dir.display()
+        ));
+    }
+
+    if !visited.insert(canonical_current) {
+        return Ok(());
+    }
+
+    let mut entries: Vec<_> = std::fs::read_dir(current_dir)
+        .map_err(|err| {
+            format!(
+                "Failed to inspect {} while seeding config from the current repo: {}",
+                current_dir.display(),
+                err
+            )
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|err| {
+            format!(
+                "Failed to inspect {} while seeding config from the current repo: {}",
+                current_dir.display(),
+                err
+            )
+        })?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|err| {
+            format!(
+                "Failed to inspect {} while seeding config from the current repo: {}",
+                path.display(),
+                err
+            )
+        })?;
+
+        if file_type.is_dir() {
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if matches!(name, ".git" | "node_modules" | "target") {
+                continue;
+            }
+            discover_repo_state(&path, root, visited, state)?;
+            continue;
+        }
+
+        match path.file_name().and_then(|name| name.to_str()) {
+            Some("package.json") => inspect_package_json(&path, state)?,
+            Some("Cargo.toml") => inspect_cargo_manifest(&path, root, state)?,
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn inspect_package_json(path: &Path, state: &mut DiscoveryState) -> Result<(), String> {
+    let content = crate::parsers::read_file_limited(path, crate::parsers::MAX_MANIFEST_BYTES)
+        .map_err(|err| {
+            format!(
+                "Failed to read {} while seeding config: {}",
+                path.display(),
+                err
+            )
+        })?;
+    let parsed: serde_json::Value = serde_json::from_str(&content).map_err(|err| {
+        format!(
+            "Failed to parse {} while seeding config: {}",
+            path.display(),
+            err
+        )
+    })?;
+
+    if let Some(name) = parsed.get("name").and_then(|value| value.as_str()) {
+        let name = name.trim();
+        if !name.is_empty() {
+            state.npm_local_packages.insert(name.to_string());
+            if let Some(scope) = extract_npm_scope(name) {
+                *state.npm_scope_counts.entry(scope.to_string()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let deps =
+        crate::parsers::package_json::parse_manifest_value(path, &parsed).map_err(|err| {
+            format!(
+                "Failed to inspect {} while seeding config: {}",
+                path.display(),
+                err
+            )
+        })?;
+    for dep in deps {
+        let observed = dep.actual_name.as_deref().unwrap_or(dep.name.as_str());
+        state.npm_dependency_usage.insert(observed.to_string());
+    }
+
+    Ok(())
+}
+
+fn cargo_package_name(path: &Path) -> Result<Option<String>, String> {
+    let content = crate::parsers::read_file_limited(path, crate::parsers::MAX_MANIFEST_BYTES)
+        .map_err(|err| {
+            format!(
+                "Failed to read {} while seeding config: {}",
+                path.display(),
+                err
+            )
+        })?;
+    let parsed: toml::Value = toml::from_str(&content).map_err(|err| {
+        format!(
+            "Failed to parse {} while seeding config: {}",
+            path.display(),
+            err
+        )
+    })?;
+    Ok(parsed
+        .get("package")
+        .and_then(|value| value.as_table())
+        .and_then(|table| table.get("name"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string))
+}
+
+fn inspect_cargo_manifest(
+    path: &Path,
+    root: &Path,
+    state: &mut DiscoveryState,
+) -> Result<(), String> {
+    if let Some(package_name) = cargo_package_name(path)? {
+        state.cargo_local_packages.insert(package_name);
+    }
+
+    let manifest = crate::parsers::cargo_toml::parse_manifest_file(path).map_err(|err| {
+        format!(
+            "Failed to inspect {} while seeding config: {}",
+            path.display(),
+            err
+        )
+    })?;
+    let project_dir = path.parent().ok_or_else(|| {
+        format!(
+            "Cargo manifest '{}' has no parent directory.",
+            path.display()
+        )
+    })?;
+
+    for dependency in manifest
+        .dependencies
+        .iter()
+        .chain(manifest.workspace_dependencies.values())
+    {
+        if let crate::parsers::cargo_toml::CargoSourceSpec::Path(local_path) = &dependency.source {
+            let resolved = std::fs::canonicalize(project_dir.join(local_path)).map_err(|err| {
+                format!(
+                    "Failed to resolve Cargo path dependency '{}' from {} while seeding config: {}",
+                    local_path,
+                    path.display(),
+                    err
+                )
+            })?;
+            if !resolved.starts_with(root) {
+                state
+                    .cargo_external_paths
+                    .insert(resolved.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn discover_current_config(project_dir: &Path) -> Result<SloppyJoeConfig, String> {
+    let root = std::fs::canonicalize(project_dir).map_err(|err| {
+        format!(
+            "Failed to inspect {} while seeding config from the current repo: {}",
+            project_dir.display(),
+            err
+        )
+    })?;
+    let mut visited = BTreeSet::new();
+    let mut state = DiscoveryState::default();
+    discover_repo_state(project_dir, &root, &mut visited, &mut state)?;
+    Ok(state.into_config())
+}
+
+pub fn discover_current_json(project_dir: &Path) -> Result<String, String> {
+    discover_current_config(project_dir).map(|config| render_config_json(&config))
 }
 
 /// Return a template config as a pretty-printed JSON string.
 pub fn template_json() -> String {
-    serde_json::to_string_pretty(&template_config()).unwrap()
+    render_config_json(&template_config())
 }
 
 /// Print a template config to stdout.
@@ -1055,6 +1378,13 @@ mod tests {
         let dir = std::env::temp_dir().join(unique);
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
     }
 
     #[test]
@@ -1221,6 +1551,155 @@ mod tests {
             config.similarity_exceptions.is_empty(),
             "public init template must not embed repo-specific similarity suppressions"
         );
+    }
+
+    #[test]
+    fn template_config_is_neutral_manual_baseline() {
+        let config = template_config();
+        assert!(config.canonical.is_empty());
+        assert!(config.internal.is_empty());
+        assert!(config.allowed.is_empty());
+        assert!(config.bootstrap_review.is_empty());
+
+        let rendered = template_json();
+        assert!(!rendered.contains("@yourorg/*"));
+        assert!(!rendered.contains("some-vetted-external-pkg"));
+        assert!(!rendered.contains("\"axios\""));
+        assert!(!rendered.contains("\"httpx\""));
+    }
+
+    #[test]
+    fn greenfield_config_npm_is_ecosystem_specific() {
+        let config = greenfield_config("npm").expect("npm greenfield config should build");
+        assert!(config.canonical.contains_key("npm"));
+        assert!(!config.canonical.contains_key("cargo"));
+        assert_eq!(
+            config.canonical["npm"]["eslint"],
+            vec!["tslint".to_string()]
+        );
+        assert!(config.internal.is_empty());
+        assert!(config.allowed.is_empty());
+    }
+
+    #[test]
+    fn greenfield_config_cargo_is_ecosystem_specific() {
+        let config = greenfield_config("cargo").expect("cargo greenfield config should build");
+        assert!(config.canonical.contains_key("cargo"));
+        assert!(!config.canonical.contains_key("npm"));
+        assert_eq!(
+            config.canonical["cargo"]["clap"],
+            vec!["structopt".to_string()]
+        );
+    }
+
+    #[test]
+    fn greenfield_config_rejects_unknown_ecosystem() {
+        let err = greenfield_config("elixir").expect_err("unsupported ecosystems must fail");
+        assert!(err.contains("Unsupported ecosystem"));
+        assert!(err.contains("npm"));
+        assert!(err.contains("cargo"));
+    }
+
+    #[test]
+    fn discover_current_config_infers_npm_internal_scope_and_review_candidates() {
+        let dir = unique_temp_dir("from-current-npm");
+        write_file(
+            &dir.join("packages/web/package.json"),
+            r#"{
+  "name": "@acme/web",
+  "dependencies": {
+    "dayjs": "1.11.13",
+    "axios": "1.9.0"
+  }
+}"#,
+        );
+        write_file(
+            &dir.join("packages/ui/package.json"),
+            r#"{
+  "name": "@acme/ui",
+  "dependencies": {
+    "moment": "2.30.1",
+    "got": "14.4.8"
+  }
+}"#,
+        );
+
+        let config =
+            discover_current_config(&dir).expect("discovery should inspect npm workspaces");
+        assert_eq!(
+            config.internal.get("npm"),
+            Some(&vec!["@acme/*".to_string()])
+        );
+        assert!(
+            !config.canonical.contains_key("npm"),
+            "from-current should not silently enforce canonical choices"
+        );
+        let groups = &config.bootstrap_review.candidate_canonical_groups["npm"];
+        assert!(
+            groups
+                .iter()
+                .any(|group| group.packages == vec!["dayjs".to_string(), "moment".to_string()])
+        );
+        assert!(
+            groups
+                .iter()
+                .any(|group| { group.packages == vec!["axios".to_string(), "got".to_string()] })
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn discover_current_config_infers_cargo_local_provenance() {
+        let sandbox = unique_temp_dir("from-current-cargo");
+        let repo = sandbox.join("repo");
+        let external = sandbox.join("shared-crate");
+
+        write_file(
+            &repo.join("Cargo.toml"),
+            r#"[workspace]
+members = ["crates/app", "crates/lib"]
+"#,
+        );
+        write_file(
+            &repo.join("crates/app/Cargo.toml"),
+            r#"[package]
+name = "app"
+version = "0.1.0"
+
+[dependencies]
+lib = { path = "../lib" }
+shared = { path = "../../../shared-crate" }
+"#,
+        );
+        write_file(
+            &repo.join("crates/lib/Cargo.toml"),
+            r#"[package]
+name = "lib"
+version = "0.1.0"
+"#,
+        );
+        write_file(
+            &external.join("Cargo.toml"),
+            r#"[package]
+name = "shared"
+version = "0.1.0"
+"#,
+        );
+
+        let config =
+            discover_current_config(&repo).expect("discovery should inspect cargo manifests");
+        let canonical_external = std::fs::canonicalize(&external).unwrap();
+        assert_eq!(
+            config.internal.get("cargo"),
+            Some(&vec!["app".to_string(), "lib".to_string()])
+        );
+        assert_eq!(
+            config.trusted_local_paths.get("cargo"),
+            Some(&vec![canonical_external.to_string_lossy().to_string()])
+        );
+
+        std::fs::remove_dir_all(&sandbox).unwrap();
     }
 
     #[test]

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -112,6 +112,13 @@ pub fn save_registry(entries: &BTreeMap<String, String>) -> Result<(), String> {
     save_registry_to(&path, entries)
 }
 
+pub(crate) fn save_registry_at_config_home(
+    config_home: &Path,
+    entries: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    save_registry_to(&config_home.join("registry.json"), entries)
+}
+
 fn save_registry_to(path: &Path, entries: &BTreeMap<String, String>) -> Result<(), String> {
     // atomic_write_json_checked handles symlink checks, dir creation, and 0o600 permissions
     crate::cache::atomic_write_json_checked(path, entries)
@@ -120,6 +127,15 @@ fn save_registry_to(path: &Path, entries: &BTreeMap<String, String>) -> Result<(
 /// Register a repo root → config path mapping.
 /// Canonicalizes both paths and validates the config path exists.
 pub fn register(repo_root: &Path, config_path: &Path) -> Result<(), String> {
+    register_at_config_home(repo_root, config_path, &config_home()?)
+}
+
+#[doc(hidden)]
+pub fn register_at_config_home(
+    repo_root: &Path,
+    config_path: &Path,
+    config_home: &Path,
+) -> Result<(), String> {
     let canon_root = std::fs::canonicalize(repo_root).map_err(|e| {
         format!(
             "Could not resolve repo root path.\n  Path: {}\n  Error: {}\n  Fix: Check that the directory exists.",
@@ -144,12 +160,12 @@ pub fn register(repo_root: &Path, config_path: &Path) -> Result<(), String> {
         ));
     }
 
-    let mut entries = load_registry()?;
+    let mut entries = load_registry_from(&config_home.join("registry.json"))?;
     entries.insert(
         canon_root.to_string_lossy().to_string(),
         canon_config.to_string_lossy().to_string(),
     );
-    save_registry(&entries)
+    save_registry_at_config_home(config_home, &entries)
 }
 
 /// Remove a repo root from the registry.

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,10 @@ Examples:
   sloppy-joe check --dir ./project              Check a specific directory
   sloppy-joe check --config /etc/sj/config.json Enforce canonical rules
   sloppy-joe check --json                       JSON output for CI
-  sloppy-joe init > /etc/sj/config.json         Generate config template
-  sloppy-joe init --register                    Create config + register cwd
+  sloppy-joe init --register                    Create config + register cwd safely
+  sloppy-joe init --greenfield --ecosystem npm   Create an ecosystem-specific starter policy
+  sloppy-joe init --from-current                 Seed config from the current repo
+  sloppy-joe init > /secure/sloppy-joe.json    Generate config template at a safe path
   sloppy-joe register                           Register cwd with existing config
   sloppy-joe list                               Show registered repos
 
@@ -148,16 +150,31 @@ enum Commands {
         #[arg(long, value_name = "DIR")]
         cache_dir: Option<PathBuf>,
     },
-    /// Print a template config to stdout
+    /// Create a config template or register a safe per-repo config
     ///
     /// Without flags, prints a JSON config template to stdout.
-    /// Use --register to create a config file and register the current repo.
+    /// Write that file outside the repo, or use --register to create and
+    /// register a safe per-repo config automatically.
     /// Use --global to create a global default config.
     ///
-    ///   sloppy-joe init > /etc/sloppy-joe/config.json
+    ///   sloppy-joe init > /secure/sloppy-joe/config.json
     ///   sloppy-joe init --register
+    ///   sloppy-joe init --greenfield --ecosystem npm
+    ///   sloppy-joe init --from-current
     ///   sloppy-joe init --global
     Init {
+        /// Create an opinionated starter policy for a specific ecosystem
+        #[arg(long, requires = "ecosystem", conflicts_with_all = ["from_current", "global"])]
+        greenfield: bool,
+
+        /// Ecosystem to use for greenfield bootstrap
+        #[arg(long = "ecosystem", value_name = "ECO", requires = "greenfield")]
+        ecosystem: Option<String>,
+
+        /// Seed config from the current repository
+        #[arg(long, conflicts_with_all = ["greenfield", "global"])]
+        from_current: bool,
+
         /// Create config at config home and register current directory
         #[arg(long)]
         register: bool,
@@ -236,12 +253,11 @@ fn repo_dirname(git_root: &std::path::Path) -> String {
         .unwrap_or_else(|| "project".to_string())
 }
 
-/// Write the template config to a path, exiting on error.
-fn write_template_config(config_path: &std::path::Path) {
-    let template = sloppy_joe::config::template_json();
-    let template_value: serde_json::Value =
-        serde_json::from_str(&template).expect("template_json produces valid JSON");
-    if let Err(e) = sloppy_joe::cache::atomic_write_json_checked(config_path, &template_value) {
+/// Write a config JSON string to a path, exiting on error.
+fn write_config_json(config_path: &std::path::Path, config_json: &str) {
+    let config_value: serde_json::Value =
+        serde_json::from_str(config_json).expect("bootstrap helpers must produce valid JSON");
+    if let Err(e) = sloppy_joe::cache::atomic_write_json_checked(config_path, &config_value) {
         eprintln!(
             "Error: Could not write config file.\n  Path: {}\n  Error: {}\n  Fix: Check file permissions.",
             config_path.display(),
@@ -249,6 +265,32 @@ fn write_template_config(config_path: &std::path::Path) {
         );
         process::exit(2);
     }
+}
+
+fn init_config_json(
+    greenfield: bool,
+    ecosystem: Option<&str>,
+    from_current: bool,
+    project_dir: &std::path::Path,
+) -> String {
+    if greenfield {
+        return sloppy_joe::config::greenfield_json(
+            ecosystem.expect("--greenfield requires --ecosystem"),
+        )
+        .unwrap_or_else(|e| {
+            eprintln!("Error: {}", e);
+            process::exit(2);
+        });
+    }
+
+    if from_current {
+        return sloppy_joe::config::discover_current_json(project_dir).unwrap_or_else(|e| {
+            eprintln!("Error: {}", e);
+            process::exit(2);
+        });
+    }
+
+    sloppy_joe::config::template_json()
 }
 
 #[tokio::main]
@@ -350,7 +392,13 @@ async fn main() {
                 }
             }
         }
-        Commands::Init { register, global } => {
+        Commands::Init {
+            greenfield,
+            ecosystem,
+            from_current,
+            register,
+            global,
+        } => {
             if register && global {
                 eprintln!(
                     "Error: Use --register or --global, not both.\n  Fix: --register creates per-project config, --global creates a shared default."
@@ -358,7 +406,7 @@ async fn main() {
                 process::exit(2);
             }
 
-            if register {
+            if register || from_current {
                 // Create config at {config_home}/{dirname}/config.json and register cwd
                 let dir = match std::env::current_dir() {
                     Ok(d) => d,
@@ -374,7 +422,7 @@ async fn main() {
                     Ok(Some(root)) => root,
                     Ok(None) => {
                         eprintln!(
-                            "Error: Not inside a git repository.\n  Path: {}\n  Fix: Run this command from inside a git repo, or use `sloppy-joe init > config.json` to create a template manually.",
+                            "Error: Not inside a git repository.\n  Path: {}\n  Fix: Run this command from inside a git repo, or write a template to a safe external path with `sloppy-joe init > /secure/sloppy-joe.json`.",
                             dir.display()
                         );
                         process::exit(2);
@@ -394,6 +442,8 @@ async fn main() {
                 let dirname = repo_dirname(&git_root);
                 let config_dir = config_home.join(&dirname);
                 let config_path = config_dir.join("config.json");
+                let config_json =
+                    init_config_json(greenfield, ecosystem.as_deref(), from_current, &git_root);
 
                 // Don't overwrite existing config
                 if config_path.exists() {
@@ -413,7 +463,7 @@ async fn main() {
                     process::exit(2);
                 }
 
-                write_template_config(&config_path);
+                write_config_json(&config_path, &config_json);
 
                 if let Err(e) = sloppy_joe::config::registry::register(&git_root, &config_path) {
                     eprintln!("Error: {}", e);
@@ -426,7 +476,17 @@ async fn main() {
                     git_root.display(),
                     config_path.display()
                 );
-                eprintln!("Edit the config to add your canonical rules.");
+                if from_current {
+                    eprintln!(
+                        "Seeded config from the current repo state. Review bootstrap_review suggestions before enforcing canonicals."
+                    );
+                } else if greenfield {
+                    eprintln!(
+                        "Created an ecosystem-specific starter policy. Review and tighten it before pushing."
+                    );
+                } else {
+                    eprintln!("Edit the config to add your policy.");
+                }
             } else if global {
                 // Create global default config at {config_home}/default/config.json
                 let config_home = match sloppy_joe::config::registry::config_home() {
@@ -448,11 +508,16 @@ async fn main() {
                     process::exit(2);
                 }
 
-                write_template_config(&config_path);
+                write_config_json(&config_path, &sloppy_joe::config::template_json());
 
                 eprintln!("Global default config created: {}", config_path.display());
-                eprintln!("Edit the config to add your canonical rules.");
+                eprintln!("Edit the config to add your policy.");
                 eprintln!("Any unregistered repo will use this config as fallback.");
+            } else if greenfield {
+                println!(
+                    "{}",
+                    init_config_json(true, ecosystem.as_deref(), false, std::path::Path::new("."))
+                );
             } else {
                 // No flags: print template to stdout (backward compat)
                 sloppy_joe::config::print_template();
@@ -680,5 +745,131 @@ mod tests {
             Err(err) => err,
         };
         assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn init_cli_parses_greenfield_with_ecosystem() {
+        let cli = Cli::try_parse_from(["sloppy-joe", "init", "--greenfield", "--ecosystem", "npm"])
+            .expect("init command should parse greenfield with ecosystem");
+
+        match cli.command {
+            Commands::Init {
+                greenfield,
+                from_current,
+                ecosystem,
+                register,
+                global,
+            } => {
+                assert!(greenfield);
+                assert!(!from_current);
+                assert_eq!(ecosystem.as_deref(), Some("npm"));
+                assert!(!register);
+                assert!(!global);
+            }
+            _ => panic!("expected init command"),
+        }
+    }
+
+    #[test]
+    fn init_cli_parses_from_current() {
+        let cli = Cli::try_parse_from(["sloppy-joe", "init", "--from-current"])
+            .expect("init command should parse from-current");
+
+        match cli.command {
+            Commands::Init {
+                greenfield,
+                from_current,
+                ecosystem,
+                register,
+                global,
+            } => {
+                assert!(!greenfield);
+                assert!(from_current);
+                assert_eq!(ecosystem, None);
+                assert!(!register);
+                assert!(!global);
+            }
+            _ => panic!("expected init command"),
+        }
+    }
+
+    #[test]
+    fn init_cli_rejects_greenfield_without_ecosystem() {
+        let err = match Cli::try_parse_from(["sloppy-joe", "init", "--greenfield"]) {
+            Ok(_) => panic!("init command should require ecosystem for greenfield"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn init_cli_rejects_greenfield_and_from_current_together() {
+        let err = match Cli::try_parse_from([
+            "sloppy-joe",
+            "init",
+            "--greenfield",
+            "--ecosystem",
+            "npm",
+            "--from-current",
+        ]) {
+            Ok(_) => panic!("init command should reject conflicting bootstrap modes"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn init_cli_rejects_greenfield_with_global() {
+        let err = match Cli::try_parse_from([
+            "sloppy-joe",
+            "init",
+            "--greenfield",
+            "--ecosystem",
+            "npm",
+            "--global",
+        ]) {
+            Ok(_) => panic!("init command should reject greenfield with global"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn init_cli_rejects_from_current_with_global() {
+        let err = match Cli::try_parse_from(["sloppy-joe", "init", "--from-current", "--global"]) {
+            Ok(_) => panic!("init command should reject from-current with global"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn init_cli_allows_greenfield_with_register() {
+        let cli = Cli::try_parse_from([
+            "sloppy-joe",
+            "init",
+            "--greenfield",
+            "--ecosystem",
+            "npm",
+            "--register",
+        ])
+        .expect("init command should allow greenfield with register");
+
+        match cli.command {
+            Commands::Init {
+                greenfield,
+                from_current,
+                ecosystem,
+                register,
+                global,
+            } => {
+                assert!(greenfield);
+                assert!(!from_current);
+                assert_eq!(ecosystem.as_deref(), Some("npm"));
+                assert!(register);
+                assert!(!global);
+            }
+            _ => panic!("expected init command"),
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,8 @@ Examples:
   sloppy-joe check --json                       JSON output for CI
   sloppy-joe init --register                    Create config + register cwd safely
   sloppy-joe init --greenfield --ecosystem npm   Create an ecosystem-specific starter policy
-  sloppy-joe init --from-current                 Seed config from the current repo
+  sloppy-joe init --from-current                 Print review-only bootstrap suggestions
+  sloppy-joe init --from-current --register      Write and register bootstrap suggestions
   sloppy-joe init > /secure/sloppy-joe.json    Generate config template at a safe path
   sloppy-joe register                           Register cwd with existing config
   sloppy-joe list                               Show registered repos
@@ -161,6 +162,7 @@ enum Commands {
     ///   sloppy-joe init --register
     ///   sloppy-joe init --greenfield --ecosystem npm
     ///   sloppy-joe init --from-current
+    ///   sloppy-joe init --from-current --register
     ///   sloppy-joe init --global
     Init {
         /// Create an opinionated starter policy for a specific ecosystem
@@ -253,18 +255,17 @@ fn repo_dirname(git_root: &std::path::Path) -> String {
         .unwrap_or_else(|| "project".to_string())
 }
 
-/// Write a config JSON string to a path, exiting on error.
-fn write_config_json(config_path: &std::path::Path, config_json: &str) {
+/// Write a config JSON string to a path.
+fn write_config_json(config_path: &std::path::Path, config_json: &str) -> Result<(), String> {
     let config_value: serde_json::Value =
         serde_json::from_str(config_json).expect("bootstrap helpers must produce valid JSON");
-    if let Err(e) = sloppy_joe::cache::atomic_write_json_checked(config_path, &config_value) {
-        eprintln!(
-            "Error: Could not write config file.\n  Path: {}\n  Error: {}\n  Fix: Check file permissions.",
+    sloppy_joe::cache::atomic_write_json_checked(config_path, &config_value).map_err(|e| {
+        format!(
+            "Could not write config file.\n  Path: {}\n  Error: {}\n  Fix: Check file permissions.",
             config_path.display(),
             e
-        );
-        process::exit(2);
-    }
+        )
+    })
 }
 
 fn init_config_json(
@@ -291,6 +292,45 @@ fn init_config_json(
     }
 
     sloppy_joe::config::template_json()
+}
+
+fn create_registered_init_config(
+    project_dir: &std::path::Path,
+    config_home: &std::path::Path,
+    config_json: &str,
+) -> Result<(PathBuf, PathBuf), String> {
+    let git_root = match sloppy_joe::config::registry::find_git_root(project_dir)? {
+        Some(root) => root,
+        None => {
+            return Err(format!(
+                "Not inside a git repository.\n  Path: {}\n  Fix: Run this command from inside a git repo, or write a template to a safe external path with `sloppy-joe init > /secure/sloppy-joe.json`.",
+                project_dir.display()
+            ));
+        }
+    };
+
+    let dirname = repo_dirname(&git_root);
+    let config_dir = config_home.join(&dirname);
+    let config_path = config_dir.join("config.json");
+
+    if config_path.exists() {
+        return Err(format!(
+            "Config already exists at {}.\n  Fix: Use `sloppy-joe register` to re-register without overwriting.",
+            config_path.display()
+        ));
+    }
+
+    std::fs::create_dir_all(&config_dir).map_err(|e| {
+        format!(
+            "Could not create config directory.\n  Path: {}\n  Error: {}\n  Fix: Check directory permissions.",
+            config_dir.display(),
+            e
+        )
+    })?;
+
+    write_config_json(&config_path, config_json)?;
+    sloppy_joe::config::registry::register_at_config_home(&git_root, &config_path, config_home)?;
+    Ok((git_root, config_path))
 }
 
 #[tokio::main]
@@ -406,7 +446,7 @@ async fn main() {
                 process::exit(2);
             }
 
-            if register || from_current {
+            if register {
                 // Create config at {config_home}/{dirname}/config.json and register cwd
                 let dir = match std::env::current_dir() {
                     Ok(d) => d,
@@ -439,36 +479,16 @@ async fn main() {
                         process::exit(2);
                     }
                 };
-                let dirname = repo_dirname(&git_root);
-                let config_dir = config_home.join(&dirname);
-                let config_path = config_dir.join("config.json");
                 let config_json =
                     init_config_json(greenfield, ecosystem.as_deref(), from_current, &git_root);
-
-                // Don't overwrite existing config
-                if config_path.exists() {
-                    eprintln!(
-                        "Error: Config already exists at {}.\n  Fix: Use `sloppy-joe register` to re-register without overwriting.",
-                        config_path.display()
-                    );
-                    process::exit(2);
-                }
-
-                if let Err(e) = std::fs::create_dir_all(&config_dir) {
-                    eprintln!(
-                        "Error: Could not create config directory.\n  Path: {}\n  Error: {}\n  Fix: Check directory permissions.",
-                        config_dir.display(),
-                        e
-                    );
-                    process::exit(2);
-                }
-
-                write_config_json(&config_path, &config_json);
-
-                if let Err(e) = sloppy_joe::config::registry::register(&git_root, &config_path) {
-                    eprintln!("Error: {}", e);
-                    process::exit(2);
-                }
+                let (git_root, config_path) =
+                    match create_registered_init_config(&dir, &config_home, &config_json) {
+                        Ok(result) => result,
+                        Err(e) => {
+                            eprintln!("Error: {}", e);
+                            process::exit(2);
+                        }
+                    };
 
                 eprintln!("Config created: {}", config_path.display());
                 eprintln!(
@@ -508,15 +528,25 @@ async fn main() {
                     process::exit(2);
                 }
 
-                write_config_json(&config_path, &sloppy_joe::config::template_json());
+                if let Err(e) =
+                    write_config_json(&config_path, &sloppy_joe::config::template_json())
+                {
+                    eprintln!("Error: {}", e);
+                    process::exit(2);
+                }
 
                 eprintln!("Global default config created: {}", config_path.display());
                 eprintln!("Edit the config to add your policy.");
                 eprintln!("Any unregistered repo will use this config as fallback.");
-            } else if greenfield {
+            } else if greenfield || from_current {
                 println!(
                     "{}",
-                    init_config_json(true, ecosystem.as_deref(), false, std::path::Path::new("."))
+                    init_config_json(
+                        greenfield,
+                        ecosystem.as_deref(),
+                        from_current,
+                        std::path::Path::new(".")
+                    )
                 );
             } else {
                 // No flags: print template to stdout (backward compat)
@@ -649,8 +679,31 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use clap::error::ErrorKind;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
 
     use super::*;
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let unique = format!(
+            "sloppy-joe-main-test-{}-{}",
+            label,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let dir = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_file(path: &std::path::Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
 
     #[test]
     fn resolve_scan_mode_defaults_to_fast() {
@@ -871,5 +924,53 @@ mod tests {
             }
             _ => panic!("expected init command"),
         }
+    }
+
+    #[test]
+    fn create_registered_init_config_writes_config_and_registry() {
+        let dir = unique_temp_dir("register");
+        let repo = dir.join("repo");
+        let config_home = dir.join("config-home");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+
+        let (git_root, config_path) = create_registered_init_config(
+            &repo,
+            &config_home,
+            &sloppy_joe::config::template_json(),
+        )
+        .expect("register helper should write config and registry");
+        let canonical_config_path = std::fs::canonicalize(&config_path).unwrap();
+
+        assert_eq!(git_root, std::fs::canonicalize(&repo).unwrap());
+        assert!(config_path.exists());
+        let registry_path = config_home.join("registry.json");
+        let registry: BTreeMap<String, String> =
+            serde_json::from_str(&std::fs::read_to_string(&registry_path).unwrap()).unwrap();
+        assert_eq!(
+            registry.get(&git_root.to_string_lossy().to_string()),
+            Some(&canonical_config_path.to_string_lossy().to_string())
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn create_registered_init_config_rejects_existing_config() {
+        let dir = unique_temp_dir("register-existing");
+        let repo = dir.join("repo");
+        let config_home = dir.join("config-home");
+        let config_path = config_home.join("repo").join("config.json");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        write_file(&config_path, "{}");
+
+        let err = create_registered_init_config(
+            &repo,
+            &config_home,
+            &sloppy_joe::config::template_json(),
+        )
+        .expect_err("existing config path must not be overwritten");
+        assert!(err.contains("Config already exists"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- add explicit config bootstrap modes for greenfield and current-repo onboarding
- make the default init template neutral and move from-current output to review-first suggestions
- harden bootstrap discovery with npm/cargo-only support, vendored-tree skips, and tested register/write flows

## Verification
- cargo test --quiet
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --check